### PR TITLE
Correction of a browser compatibility problem

### DIFF
--- a/solarSystem.js
+++ b/solarSystem.js
@@ -121,7 +121,7 @@ function explore(planet){
 		// Resource(s)
 		if (planetsData[planet].resource) {
 			var toAdd = planetsData[planet].resource.split(',');
-			for(let i = 0; i < toAdd.length; i++) {
+			for(var i = 0; i < toAdd.length; i++) {
 				switch(Game.resourceData[toAdd[i]].category) {
 					case "earth":
 						document.getElementById(toAdd[i] + "Nav").className = "earth";


### PR DESCRIPTION
"let" was established before about 1 year in a browser, the variable which is still new.
This problem is held for much of the person who can't buy rocket fuel.

"let" was authorized by the following version.
Internet Explorer 11, Chrome 41, Firefox 44, Opera 17