### PR TITLE
Fix typo in Future Plans URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -7212,7 +7212,7 @@
 										<br>
 										<a href="https://plaza.dsolver.ca/">The Plaza: </a><a href="https://plaza.dsolver.ca/games/space-company">Game</a>
 										<br>
-										<a href="https://github.com/sparticle999/SpaceCompany#changelog">Changelog</a> / <a href="hhttps://www.reddit.com/r/SpaceCompany/wiki/futureplans">Future Plans</a>
+										<a href="https://github.com/sparticle999/SpaceCompany#changelog">Changelog</a> / <a href="https://www.reddit.com/r/SpaceCompany/wiki/futureplans">Future Plans</a>
 										<br>
 										<a href="https://www.reddit.com/r/SpaceCompany/wiki/index">Wiki</a>
 									</span>


### PR DESCRIPTION
Hi,

This is a simple fix to a typo in the link to the Future Plans.