### PR TITLE
Add Gain Max Plasma

### DIFF
--- a/resources.js
+++ b/resources.js
@@ -87,6 +87,23 @@ function gainPlasma(){
 	}
 }
 
+function gainMaxPlasma(){
+	var energyCost = 1000;
+	var hydrogenCost = 10;
+	var current = plasma;
+	var current2 = hydrogen;
+	var capacity = getMaxPlasma();
+	var amount = Math.floor(Math.min(Math.floor(Math.min(energy/energyCost,energy/hydrogenCost)), capacity - current));
+	var requiredEnergy = amount * energyCost;
+	var requiredHydrogen = amount * hydrogenCost;
+	if(amount > 0 && energy >= requiredEnergy && hydrogen >= requiredHydrogen){
+		energy -= requiredEnergy;
+		hydrogen -= requiredHydrogen;
+		plasma += amount;
+		Game.statistics.add('manualResources');
+	}
+}
+
 function gainUranium(){
 	if(uranium < uraniumStorage){
 		uranium += 1;


### PR DESCRIPTION
A max gain button is set in a plasma resource in the substitute which can't change the energy from EMC to plasma at present.
The new way to invent plasma at high speed is related to a game balance.