### PR TITLE
Add completion counts to achievement headers

### DIFF
--- a/ui/achievementUI.js
+++ b/ui/achievementUI.js
@@ -11,7 +11,7 @@
     instance.initialise = function() {
         this.categoryTemplate = Handlebars.compile(
             ['<td>',
-                '<h3 class="default btn-link">{{name}}</h3>',
+                '<h3 class="default btn-link">{{name}} (<span id="{{id}}_unlocked">0</span>/<span id="{{id}}_total">0</span>)</h3>',
                 '<table class="table" id="{{id}}"></table>',
                 '</td>'].join('\n'));
 
@@ -31,12 +31,31 @@
     };
 
     instance.update = function(delta) {
+        var categoryCounts = {};
+        var updateCategories = false;
+        
+        for(var category in this.categoryElements) {
+          categoryCounts[category] = { unlocked: 0, total: 0 };
+        }
+        
         for(var id in Game.achievements.entries) {
             var data = Game.achievements.entries[id];
+            
+            categoryCounts[data.category].unlocked += data.unlocked + 1;
+            categoryCounts[data.category].total += data.brackets.length;
 
             if(data.displayNeedsUpdate === true) {
                 this.updateDisplay(id);
+                updateCategories = true;
             }
+        }
+        
+        if (updateCategories === true) {
+          for(var category in this.categoryElements) {
+            var id = this.categoryElements[category].id;
+            $('#' + id + '_unlocked').text(categoryCounts[category].unlocked);
+            $('#' + id + '_total').text(categoryCounts[category].total);
+          }
         }
     };
 


### PR DESCRIPTION
Example: "Producers (241/415)"

Inspired by the display on limited-purchase items like rocket parts, this adds a numeric total and goal for the achievements. Like most incremental fans, I like to see numbers go up, and I was tired of counting stars every so often so I made the game do it for me. ;)

I'm sure this could be implemented more efficiently. To minimize the chance of unintentionally breaking something, I kept all changes in the UI component, which recalculates the necessary numbers when the display is updated.

My code doesn't follow existing code patterns for rocket parts or battery efficiency, but achievements are rather special and I wasn't sure how to apply those design choices here. I won't be offended at all if you re-implement this idea in a totally different way.