### PR TITLE
Rebuild Bootstrap tooltips during achievement updates

### DIFF
--- a/achievements.js
+++ b/achievements.js
@@ -142,12 +142,19 @@ Game.achievements = (function() {
         console.debug("Loaded " + this.achievementCount + " (" + this.achievementCountIncludingTiers +") Achievements");
     };
 
-    instance.getAchievementTitle = function(data) {
+    instance.getAchievementTitle = function(data, for_tooltip) {
         if(data.unlocked === data.brackets.length - 1) {
-            return data.title.replace('%s', Game.settings.format(data.brackets[data.unlocked])) + " (Completed)";
+            var title = data.title.replace('%s', Game.settings.format(data.brackets[data.unlocked]));
+            if(for_tooltip === true) {
+                title += " (Completed)";
+            }
+            return title;
         } else {
-            var progress = data.progressEvaluator(data.brackets[data.unlocked+1]);
-            return data.title.replace('%s', Game.settings.format(data.brackets[data.unlocked+1])) + ' (' + Math.floor(100 * progress) + '%)';
+            var title = data.title.replace('%s', Game.settings.format(data.brackets[data.unlocked+1]));
+            if(for_tooltip === true) {
+                title += ' (' + data.progressDisplay + '%)';
+            }
+            return title;
         }
     };
 
@@ -156,8 +163,8 @@ Game.achievements = (function() {
             var data = this.entries[id];
             var bracket = data.brackets[data.unlocked + 1];
 
-                Game.notifySuccess("Achievement Reached", this.getAchievementTitle(data));
             if(data.unlocked < data.brackets.length - 1 && data.evaluator(bracket)) {
+                Game.notifySuccess("Achievement Reached", this.getAchievementTitle(data, false));
 
                 this.unlock(id, data.unlocked + 1);
 

--- a/achievements.js
+++ b/achievements.js
@@ -154,13 +154,17 @@ Game.achievements = (function() {
     instance.update = function(delta) {
         for(var id in this.entries) {
             var data = this.entries[id];
+            var bracket = data.brackets[data.unlocked + 1];
 
-            if(data.unlocked < data.brackets.length - 1 && data.evaluator(data.brackets[data.unlocked + 1])) {
                 Game.notifySuccess("Achievement Reached", this.getAchievementTitle(data));
+            if(data.unlocked < data.brackets.length - 1 && data.evaluator(bracket)) {
 
                 this.unlock(id, data.unlocked + 1);
 
                 newUnlock('more');
+            } else if(data.unlocked < data.brackets.length - 1) {
+                var progressDisplay = Math.floor(100 * data.progressEvaluator(bracket));
+                this.updateProgress(id, progressDisplay);
             }
         }
     };
@@ -168,6 +172,13 @@ Game.achievements = (function() {
     instance.unlock = function(id, tier) {
         if(this.entries[id].unlocked < tier) {
             this.entries[id].unlocked = tier;
+            this.entries[id].displayNeedsUpdate = true;
+        }
+    };
+
+    instance.updateProgress = function(id, progress) {
+        if(this.entries[id].progressDisplay != progress) {
+            this.entries[id].progressDisplay = progress;
             this.entries[id].displayNeedsUpdate = true;
         }
     };
@@ -183,6 +194,7 @@ Game.achievements = (function() {
             evaluator: evaluator,
             progressEvaluator: progressEvaluator,
             unlocked: -1,
+            progressDisplay: -1,
             brackets: brackets,
             displayNeedsUpdate: true
         };

--- a/ui/achievementUI.js
+++ b/ui/achievementUI.js
@@ -118,9 +118,7 @@ Game.achievementsUI = (function(){
         var div = $('#' + id + "_div");
         var bg = $('#' + id + "_bg");
 
-        div.tooltip('destroy');
-        div.prop('title', Game.achievements.getAchievementTitle(data));
-        div.tooltip();
+        div.attr('data-original-title', Game.achievements.getAchievementTitle(data));
 
         div.css('border-color', Game.constants.achievementBracketColors[data.unlocked]);
 

--- a/ui/achievementUI.js
+++ b/ui/achievementUI.js
@@ -118,7 +118,7 @@ Game.achievementsUI = (function(){
         var div = $('#' + id + "_div");
         var bg = $('#' + id + "_bg");
 
-        div.attr('data-original-title', Game.achievements.getAchievementTitle(data));
+        div.attr('data-original-title', Game.achievements.getAchievementTitle(data, true));
 
         div.css('border-color', Game.constants.achievementBracketColors[data.unlocked]);
 

--- a/ui/achievementUI.js
+++ b/ui/achievementUI.js
@@ -106,7 +106,7 @@ Game.achievementsUI = (function(){
 
         var html = this.entryTemplate(data);
         this.categoryElements[data.category].colc++;
-        this.categoryElements[data.category].col.append($(html));
+        this.categoryElements[data.category].col.append($(html)).find('[data-toggle="tooltip"]').tooltip();
 
         if(this.categoryElements[data.category].colc >= Game.constants.achievementIconsPerRow) {
             this.createCategoryRow(data.category);
@@ -118,7 +118,9 @@ Game.achievementsUI = (function(){
         var div = $('#' + id + "_div");
         var bg = $('#' + id + "_bg");
 
+        div.tooltip('destroy');
         div.prop('title', Game.achievements.getAchievementTitle(data));
+        div.tooltip();
 
         div.css('border-color', Game.constants.achievementBracketColors[data.unlocked]);
 


### PR DESCRIPTION
The Bootstrap-based tooltips for achievements suffer from sporadic issues such as:

* not displaying the Bootstrap UI at all
* showing both Bootstrap and native browser tooltips
* showing the template text instead of the current achievement text

This PR updates the Bootstrap tooltip JS when achievements are created or updated, so they display consistently.

Tested on an existing game, a new game, and after unlocking achievements during a play session.