### PR TITLE
Draining resources time display

### DIFF
--- a/core.js
+++ b/core.js
@@ -79,30 +79,31 @@ function fixStorageRounding() {
 	}
 }
 
-function refreshTimeUntilFull() {
-    setTimeUntilDisplayTest('plasmaFullTime', plasma, getMaxPlasma(), plasmaps);
-    setTimeUntilDisplayTest('energyFullTime', energy, getMaxEnergy(), energyps);
-    setTimeUntilDisplayTest('uraniumFullTime', uranium, uraniumStorage, uraniumps);
-    setTimeUntilDisplayTest('lavaFullTime', lava, lavaStorage, lavaps);
-    setTimeUntilDisplayTest('oilFullTime', oil, oilStorage, oilps);
-    setTimeUntilDisplayTest('metalFullTime', metal, metalStorage, metalps);
-    setTimeUntilDisplayTest('gemFullTime', gem, gemStorage, gemps);
-    setTimeUntilDisplayTest('charcoalFullTime', charcoal, charcoalStorage, charcoalps);
-    setTimeUntilDisplayTest('woodFullTime', wood, woodStorage, woodps);
-    setTimeUntilDisplayTest('siliconFullTime', silicon, siliconStorage, siliconps);
-    setTimeUntilDisplayTest('lunariteFullTime', lunarite, lunariteStorage, lunariteps);
-    setTimeUntilDisplayTest('methaneFullTime', methane, methaneStorage, methaneps);
-    setTimeUntilDisplayTest('titaniumFullTime', titanium, titaniumStorage, titaniumps);
-    setTimeUntilDisplayTest('goldFullTime', gold, goldStorage, goldps);
-    setTimeUntilDisplayTest('silverFullTime', silver, silverStorage, silverps);
-    setTimeUntilDisplayTest('hydrogenFullTime', hydrogen, hydrogenStorage, hydrogenps);
-    setTimeUntilDisplayTest('heliumFullTime', helium, heliumStorage, heliumps);
-    setTimeUntilDisplayTest('iceFullTime', ice, iceStorage, iceps);
-    setTimeUntilDisplayTest('meteoriteFullTime', meteorite, meteoriteStorage, meteoriteps);
+function refreshTimeUntilLimit() {
+    setTimeUntilDisplayTest('plasmaLimitType', 'plasmaLimitTime', plasma, getMaxPlasma(), plasmaps);
+    setTimeUntilDisplayTest('energyLimitType', 'energyLimitTime', energy, getMaxEnergy(), energyps);
+    setTimeUntilDisplayTest('uraniumLimitType', 'uraniumLimitTime', uranium, uraniumStorage, uraniumps);
+    setTimeUntilDisplayTest('lavaLimitType', 'lavaLimitTime', lava, lavaStorage, lavaps);
+    setTimeUntilDisplayTest('oilLimitType', 'oilLimitTime', oil, oilStorage, oilps);
+    setTimeUntilDisplayTest('metalLimitType', 'metalLimitTime', metal, metalStorage, metalps);
+    setTimeUntilDisplayTest('gemLimitType', 'gemLimitTime', gem, gemStorage, gemps);
+    setTimeUntilDisplayTest('charcoalLimitType', 'charcoalLimitTime', charcoal, charcoalStorage, charcoalps);
+    setTimeUntilDisplayTest('woodLimitType', 'woodLimitTime', wood, woodStorage, woodps);
+    setTimeUntilDisplayTest('siliconLimitType', 'siliconLimitTime', silicon, siliconStorage, siliconps);
+    setTimeUntilDisplayTest('lunariteLimitType', 'lunariteLimitTime', lunarite, lunariteStorage, lunariteps);
+    setTimeUntilDisplayTest('methaneLimitType', 'methaneLimitTime', methane, methaneStorage, methaneps);
+    setTimeUntilDisplayTest('titaniumLimitType', 'titaniumLimitTime', titanium, titaniumStorage, titaniumps);
+    setTimeUntilDisplayTest('goldLimitType', 'goldLimitTime', gold, goldStorage, goldps);
+    setTimeUntilDisplayTest('silverLimitType', 'silverLimitTime', silver, silverStorage, silverps);
+    setTimeUntilDisplayTest('hydrogenLimitType', 'hydrogenLimitTime', hydrogen, hydrogenStorage, hydrogenps);
+    setTimeUntilDisplayTest('heliumLimitType', 'heliumLimitTime', helium, heliumStorage, heliumps);
+    setTimeUntilDisplayTest('iceLimitType', 'iceLimitTime', ice, iceStorage, iceps);
+    setTimeUntilDisplayTest('meteoriteLimitType', 'meteoriteLimitTime', meteorite, meteoriteStorage, meteoriteps);
 }
 
-function setTimeUntilDisplayTest(target, current, max, perSecond) {
-	var targetElement = $('#' + target);
+function setTimeUntilDisplayTest(targetLimitType, targetLimitTime, current, max, perSecond) {
+	var targetTypeElement = $('#' + targetLimitType);
+	var targetTimeElement = $('#' + targetLimitTime)
 	var value = 0;
 	var isDraining = false;
 	if(perSecond > 0) {
@@ -114,15 +115,18 @@ function setTimeUntilDisplayTest(target, current, max, perSecond) {
 
 	if(value > 0) {
         var formattedTimeTest = Game.utils.getFullTimeDisplay(value);
-        targetElement.text(formattedTimeTest);
+        targetTimeElement.text(formattedTimeTest);
 
         if(isDraining){
-            targetElement.addClass('red');
+            targetTypeElement.text('empty');
+            targetTimeElement.addClass('red');
 		} else {
-            targetElement.removeClass('red');
+            targetTypeElement.text('full');
+            targetTimeElement.removeClass('red');
         }
     } else {
-        targetElement.text('N/A');
+        targetTypeElement.text('full');
+        targetTimeElement.text('N/A');
 	}
 }
 

--- a/game.js
+++ b/game.js
@@ -76,7 +76,7 @@ var Game = (function() {
 
     instance.slowUpdate = function(self, delta) {
         refreshConversionDisplay();
-        refreshTimeUntilFull();
+        refreshTimeUntilLimit();
 
         checkStorages();
 

--- a/index.html
+++ b/index.html
@@ -555,7 +555,7 @@
 									<span>
 										Plasma is the 4th state of matter and is used by Tier 4 machines and large space structures as an extreme power source for your company. At first you can hold 100,000 plasma at once, but you can unlock and purchase Plasma Storage Units to increase this number.
 										<br>
-										Time remaining until full storage: <b><span id="plasmaFullTime">N/A</span></b>
+										Time remaining until <span id="plasmaLimitType">full</span> storage: <b><span id="plasmaLimitTime">N/A</span></b>
 										<br>
 										1 Plasma is created by infusing <span id="manualPlasmaHydrogenCost">10</span> Hydrogen with <span id="manualPlasmaEnergyCost">1000</span> Energy.
 									</span>
@@ -654,7 +654,7 @@
 									<span>
 										Energy is created by power sources such as steam engines, solar power and advances even to fusion power and nuclear energy. The maximum you can hold to start with is 100,000 Energy, but batteries are unlockable which can increase this.
 										<br>
-										Time remaining until full storage: <b><span id="energyFullTime">N/A</span></b>
+										Time remaining until <span id="energyLimitType">full</span> storage: <b><span id="energyLimitTime">N/A</span></b>
 										<br>
 									</span>
 									<br>
@@ -860,7 +860,7 @@
 									<span>
 										Upgrade your Uranium storage size to <span id="uraniumNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="uraniumFullTime">N/A</span></b>
+										Time remaining until <span id="uraniumLimitType">full</span> storage: <b><span id="uraniumLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="uraniumStorageCost">50</span> Uranium, <span id="uraniumStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -976,7 +976,7 @@
 									<span>
 										Upgrade your Oil storage size to <span id="oilNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="oilFullTime">N/A</span></b>
+										Time remaining until <span id="oilLimitType">full</span> storage: <b><span id="oilLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="oilStorageCost">50</span> Oil, <span id="oilStorageMetalCost">20</span> Metal.
 									</span>
@@ -1092,7 +1092,7 @@
 									<span>
 										Upgrade your Metal storage size to <span id="metalNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="metalFullTime">N/A</span></b>
+										Time remaining until <span id="metalLimitType">full</span> storage: <b><span id="metalLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="metalStorageCost">50</span> Metal.
 									</span>
@@ -1210,7 +1210,7 @@
 									<span>
 										Upgrade your gem storage size to <span id="gemNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="gemFullTime">N/A</span></b>
+										Time remaining until <span id="gemLimitType">full</span> storage: <b><span id="gemLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="gemStorageCost">50</span> Gems, <span id="gemStorageMetalCost">20</span> Metal.
 									</span>
@@ -1329,7 +1329,7 @@
 									<span>
 										Upgrade your Charcoal storage size to <span id="charcoalNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="charcoalFullTime">N/A</span></b>
+										Time remaining until <span id="charcoalLimitType">full</span> storage: <b><span id="charcoalLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="charcoalStorageCost">50</span> Charcoal, <span id="charcoalStorageMetalCost">20</span> Metal.
 									</span>
@@ -1455,7 +1455,7 @@
 									<span>
 										Upgrade your wood storage size to <span id="woodNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="woodFullTime">N/A</span></b>
+										Time remaining until <span id="woodLimitType">full</span> storage: <b><span id="woodLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="woodStorageCost">50</span> wood, <span id="woodStorageMetalCost">20</span> Metal.
 									</span>
@@ -1573,7 +1573,7 @@
 									<span>
 										Upgrade your Silicon storage size to <span id="siliconNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="siliconFullTime">N/A</span></b>
+										Time remaining until <span id="siliconLimitType">full</span> storage: <b><span id="siliconLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="siliconStorageCost">50</span> Silicon, <span id="siliconStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -1691,7 +1691,7 @@
 									<span>
 										Upgrade your Lunarite storage size to <span id="lunariteNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="lunariteFullTime">N/A</span></b>
+										Time remaining until <span id="lunariteLimitType">full</span> storage: <b><span id="lunariteLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="lunariteStorageCost">50</span> Lunarite, <span id="lunariteStorageMetalCost">200</span> Metal.
 									</span>
@@ -1809,7 +1809,7 @@
 									<span>
 										Upgrade your methane storage size to <span id="methaneNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="methaneFullTime">N/A</span></b>
+										Time remaining until <span id="methaneLimitType">full</span> storage: <b><span id="methaneLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="methaneStorageCost">50</span> Methane, <span id="methaneStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -1928,7 +1928,7 @@
 									<span>
 										Upgrade your Titanium storage size to <span id="titaniumNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="titaniumFullTime">N/A</span></b>
+										Time remaining until <span id="titaniumLimitType">full</span> storage: <b><span id="titaniumLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="titaniumStorageCost">50</span> Titanium, <span id="titaniumStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2046,7 +2046,7 @@
 									<span>
 										Upgrade your Gold storage size to <span id="goldNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="goldFullTime">N/A</span></b>
+										Time remaining until <span id="goldLimitType">full</span> storage: <b><span id="goldLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="goldStorageCost">50</span> Gold, <span id="goldStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2164,7 +2164,7 @@
 									<span>
 										Upgrade your silver storage size to <span id="silverNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="silverFullTime">N/A</span></b>
+										Time remaining until <span id="silverLimitType">full</span> storage: <b><span id="silverLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="silverStorageCost">50</span> Silver, <span id="silverStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2282,7 +2282,7 @@
 									<span>
 										Upgrade your Lava storage size to <span id="lavaNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="lavaFullTime">N/A</span></b>
+										Time remaining until <span id="lavaLimitType">full</span> storage: <b><span id="lavaLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="lavaStorageCost">50</span> Lava, <span id="lavaStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2400,7 +2400,7 @@
 									<span>
 										Upgrade your Hydrogen storage size to <span id="hydrogenNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="hydrogenFullTime">N/A</span></b>
+										Time remaining until <span id="hydrogenLimitType">full</span> storage: <b><span id="hydrogenLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="hydrogenStorageCost">50</span> Hydrogen, <span id="hydrogenStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2518,7 +2518,7 @@
 									<span>
 										Upgrade your Helium storage size to <span id="heliumNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="heliumFullTime">N/A</span></b>
+										Time remaining until <span id="heliumLimitType">full</span> storage: <b><span id="heliumLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="heliumStorageCost">50</span> Helium, <span id="heliumStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2636,7 +2636,7 @@
 									<span>
 										Upgrade your Ice storage size to <span id="iceNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="iceFullTime">N/A</span></b>
+										Time remaining until <span id="iceLimitType">full</span> storage: <b><span id="iceLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="iceStorageCost">50</span> Ice, <span id="iceStorageLunariteCost">20</span> Lunarite.
 									</span>
@@ -2757,7 +2757,7 @@
 									<span>
 										Upgrade your Meteorite storage size to <span id="meteoriteNextStorage">100</span>.
 										<br>
-										Time remaining until full storage: <b><span id="meteoriteFullTime">N/A</span></b>
+										Time remaining until <span id="meteoriteLimitType">full</span> storage: <b><span id="meteoriteLimitTime">N/A</span></b>
 										<br>
 										Costs <span id="meteoriteStorageCost">50</span> Meteorite, <span id="meteoriteStorageLunariteCost">400</span> Lunarite.
 									</span>


### PR DESCRIPTION
Display 'Time remaining until empty storage' for resources that are draining.

Current behavior: 'Time remaining until full storage' is always displayed regardless of whether there is a net gain or net loss.

Notable changes:
- changed the word 'Full' to 'Limit' in the resource span ids to better reflect what's being displayed
- renamed refreshTimeUntilFull() to refreshTimeUntilLimit() in core.js for the same reason 
- changed the signature of setTimeUntilDisplayTest() in core.js to take another span, which contains 'full' or 'empty'

If any of those are issues then please let me know.