### PR TITLE
Update auto resource bindings

### DIFF
--- a/ui/resourceUI.js
+++ b/ui/resourceUI.js
@@ -17,6 +17,9 @@ Game.resourcesUI = (function(){
 				Game.ui.bindElement(RESOURCE[id] + 'NextStorage', this.createNextStorageDelegate(RESOURCE[id]));
 			}
 		}
+
+		// the auto bindings need to be updated after this is done
+		Game.ui.updateAutoDataBindings();
 	};
 
 	instance.update = function(delta) {


### PR DESCRIPTION
Game.ui.updateAutoDataBindings() needs to be called after the resource bindings are created in Game.resourceUI.initialise().

This fixes the N/A issue on the EMC page.