### PR TITLE
Fixed a typo in Dead Werewolf Finder

### DIFF
--- a/index.html
+++ b/index.html
@@ -2494,7 +2494,7 @@
 							<tr id="silverTier5" class="hidden">
 								<td>
 									<h3 class="default btn-link">
-										Dead Werewolf Finer: <span id="werewolf">0</span>
+										Dead Werewolf Finder: <span id="werewolf">0</span>
 									</h3>
 									<span>
 										The Silver bullets used to kill werewolfs are made from silver that has been compressed well over 1000 times. Extracting them will prove beneficial for your production.


### PR DESCRIPTION
It was "Dead Werewolf Finer". This seems wrong.