### PR TITLE
Prevent self-XSS though companyName in updateCompanyName

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -312,7 +312,13 @@ Game.settings = (function(){
     };
 
     instance.updateCompanyName = function(){
-        document.getElementById("companyName").innerHTML = companyName;
+        document.getElementById("companyName").innerHTML = 
+            companyName //Escape unsafe HTML characters in companyName to prevent XXS
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#x27;");
     }
 
     return instance;


### PR DESCRIPTION
Prevent self-XSS (Cross Site Scripting) by stopping the user from being able to create HTML tags which can be used to run custom Javascript when setting the companyName. (Note: This wont have a visible difference for what the user sees)
For info on "What is XSS": https://www.owasp.org/index.php/Top_10-2017_A7-Cross-Site_Scripting_(XSS)
or preventing it: https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet