### PR TITLE
Notation changes

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -83,11 +83,11 @@ Game.utils = (function(){
         };
     };
 
-    instance.formatScientificNotation2 = function(value) {
-        return Game.utils.formatScientificNotation(value, true)
+    instance.formatScientificNotation = function(value) {
+        return Game.utils.formatEngineeringNotation(value, true)
     };
 
-    instance.formatScientificNotation = function(value, useExponentNotation){
+    instance.formatEngineeringNotation = function(value, useExponentNotation){
         if (value === 0 || (Math.abs(value) > -1000 && Math.abs(value) < 1000))
         {
             return Game.utils.formatRaw(value);
@@ -105,10 +105,10 @@ Game.utils = (function(){
         }
 
         if(useExponentNotation === true) {
-            return sign + output + 'E+' + exp;
+            return sign + output + 'e+' + exp;
         }
 
-        return sign + output + '*10^' + exp;
+        return sign + output + 'E+' + exp;
     };
 
     instance.formatRounded = function(value)

--- a/utils.js
+++ b/utils.js
@@ -88,7 +88,7 @@ Game.utils = (function(){
     };
 
     instance.formatScientificNotation = function(value, useExponentNotation){
-        if (value === 0 || (Math.abs(value) > -100 && Math.abs(value) < 100))
+        if (value === 0 || (Math.abs(value) > -1000 && Math.abs(value) < 1000))
         {
             return Game.utils.formatRaw(value);
         }

--- a/utils.js
+++ b/utils.js
@@ -83,6 +83,10 @@ Game.utils = (function(){
         };
     };
 
+    instance.formatScientificNotation2 = function(value) {
+        return Game.utils.formatEngineeringNotation(value, true)
+    };
+    
     instance.formatScientificNotation = function(value) {
         return Game.utils.formatEngineeringNotation(value, true)
     };
@@ -109,6 +113,8 @@ Game.utils = (function(){
         }
 
         return sign + output + 'E+' + exp;
+      
+        return sign + output + 'e' + exp;
     };
 
     instance.formatRounded = function(value)


### PR DESCRIPTION
Updates scientific notation to use an “e” instead of an “E”, removes the complicated “*10^” notation, adds engineering instead if that notation, uses the “E+” from the earlier scientific notation. Also fixes the x.xxe+2 And makes it start at e+3.