### PR TITLE
Grammar, you fool!

### DIFF
--- a/index.html
+++ b/index.html
@@ -1624,7 +1624,7 @@
 										Laser Cutter: <span id="laserCutter">0</span>
 									</h3>
 									<span>
-										Laser Cutters slice trees (and fingers) quicker than axes and produce a lot more wood.
+										Laser Cutters slice trees (and fingers) more quickly than axes and produce a lot more wood.
 										<br>
 										Produces <span id="laserCutterOutput">6</span> wood per second.
 										<br>


### PR DESCRIPTION
You used the incorrect form of the comparative adverb for quickness.