### PR TITLE
Fixes sync issue between meteorite 2 tier cost in UI/Data

### DIFF
--- a/data/techData.js
+++ b/data/techData.js
@@ -392,7 +392,7 @@ Game.techData = (function () {
         type: TECH_TYPE.UNLOCK,
         costType: COST_TYPE.FIXED,
         cost: {
-            'science': 75000
+            'science': 100000
         },
         newResources: ['meteoriteTier2'],
         tabAlerts: ['resources']


### PR DESCRIPTION
UI shows that both tier 1 + tier 2 meteorite costs are the same, at 75,000. However the actual code expects user's to have 100,000 before buying. This makes the actual UI correspond to the expected value.